### PR TITLE
fix: don't add fields which are of "empty" type

### DIFF
--- a/src/lib/generateFromRosMsg.spec.ts
+++ b/src/lib/generateFromRosMsg.spec.ts
@@ -184,3 +184,31 @@ float64 z
 
   t.is(result, expected);
 });
+
+test('generateFromRosMsg with empty type', (t) => {
+  const result = generateFromRosMsg(
+    `MSG: test_msgs/HasOneEmpty
+  test_msgs/Empty empty
+  test_msgs/Normal normal
+
+  ===
+  MSG: test_msgs/Empty
+
+  ===
+  MSG: test_msgs/Normal
+  float64 x
+  float64 y`,
+    'Prefix'
+  );
+
+  const expected = `export interface PrefixTestMsgsHasOneEmpty {
+  normal: PrefixTestMsgsNormal;
+}
+
+export interface PrefixTestMsgsNormal {
+  x: number;
+  y: number;
+}`;
+
+  t.is(result, expected);
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix

**What is the current behavior?**

If a message has a property which is of another (complex) type which itself is empty the generated types contained that property which referred to a type which doesn't exists (since it wasn't generated due to being empty).

```
MSG: test_msgs/HasOneEmpty
test_msgs/Empty empty
test_msgs/Normal normal

===
MSG: test_msgs/Empty

===
MSG: test_msgs/Normal
float64 x
float64 y
```

**What is the new behavior (if this is a feature change)?**

A property gets only added it the complex type is not empty (not a "marker" interface).

**Other information**:

I encountered this problem because an action didn't have a feedback :thinking:.

```
# ====== DO NOT MODIFY! AUTOGENERATED FROM AN ACTION DEFINITION ======

# FEEDBACK

# There is no feedback.
```

@MrBlenny 