### PR TITLE
fix: convert non-number `const` values to valid `enum` values

### DIFF
--- a/src/lib/generateFromRosMsg.spec.ts
+++ b/src/lib/generateFromRosMsg.spec.ts
@@ -212,3 +212,35 @@ export interface PrefixTestMsgsNormal {
 
   t.is(result, expected);
 });
+
+test('generateFromRosMsg with bool enum', (t) => {
+  const result = generateFromRosMsg(
+    `MSG: test_msgs/State
+  bool OFF = 0
+  bool ON = 1
+`
+  );
+
+  const expected = `export enum TestMsgsStateConst {
+  OFF = 0,
+  ON = 1,
+}`;
+
+  t.is(result, expected);
+});
+
+test('generateFromRosMsg with string enum', (t) => {
+  const result = generateFromRosMsg(
+    `MSG: test_msgs/State
+  string OFF = 'off'
+  string ON = 'on'
+`
+  );
+
+  const expected = `export enum TestMsgsStateConst {
+  OFF = 'off',
+  ON = 'on',
+}`;
+
+  t.is(result, expected);
+});

--- a/src/lib/generateFromRosMsg.ts
+++ b/src/lib/generateFromRosMsg.ts
@@ -40,6 +40,22 @@ export const generateFromRosMsg = (
     );
   }
 
+  function toEnumValue(field: RosMsgField) {
+    if (field.type === 'bool') {
+      return field.value ? 1 : 0;
+    }
+    if (
+      field.type === 'char' ||
+      field.type === 'wchar' ||
+      field.type === 'string' ||
+      field.type === 'wstring'
+    ) {
+      return `'${field.value}'`;
+    }
+
+    return field.value;
+  }
+
   return messageDefinitions
     .map((definition) => {
       // Get the interface key
@@ -67,7 +83,7 @@ export const generateFromRosMsg = (
 
       const tsEnum = defConstants
         .map((param) => {
-          return `  ${param.name} = ${param.value},`;
+          return `  ${param.name} = ${toEnumValue(param)},`;
         })
         .join('\n');
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* fixes #6

**What is the current behavior?**

- const values get one-to-one copied even if the values (e.g. `true`, `string`) are not compatible with `enum`

**What is the new behavior (if this is a feature change)?**

- values get converted (`true` -> 1, `false` -> 0, `text` -> `'text'`)

**Other information**:

`TS18033 Only numeric enums can have computed members, but this expression has type 'false'. If you do not need exhaustiveness checks, consider using an object literal instead.`
