### PR TITLE
Correct Duration primitive

### DIFF
--- a/src/lib/primitives.ts
+++ b/src/lib/primitives.ts
@@ -20,5 +20,5 @@ export const primitives = {
   wstring: 'string',
   wchar: 'string',
   time: '{ sec: number, nanosec: number }',
-  duration: 'number',
+  duration: '{ sec: number, nanosec: number }',
 };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Duration types are incorrectly output as `number`

- **What is the new behavior (if this is a feature change)?**

Duration types are correctly output as the same as a `Time` type

- **Other information**:

Thank you for the awesome tool! Just noticed this when working w/ moveit_msgs and trajectory_msgs that have a lot of durations.