### PR TITLE
workaround for https://github.com/foxglove/rosmsg/issues/39

### DIFF
--- a/src/lib/rosTypescriptGenerator.ts
+++ b/src/lib/rosTypescriptGenerator.ts
@@ -7,17 +7,40 @@ import { IConfig } from '../types/config';
 import { generateFromRosMsg } from './generateFromRosMsg';
 import { getMsgFilesData } from './readMsgFiles';
 
+const disambiguatePkgOfPropertyTypes = (joinedMessages: string) => {
+  // this is a workaround for https://github.com/foxglove/rosmsg/issues/39
+  let lines = joinedMessages.split("\n");
+  let re_new_msg = /^MSG: (.*)\/.*$/;
+  let re_field = /^([a-zA-Z0-9\[\]]+) ([a-zA-Z0-9]+).*/
+  let pkg = undefined;
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+    let match = re_new_msg.exec(line);
+    if (match) {
+      pkg = match[1];
+    } else {
+      let match = re_field.exec(line);
+      if (match && match[1] !== "Header" && match[1][0] === match[1][0].toUpperCase()) {
+        lines[i] = `${pkg}/${lines[i]}`;
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
 export const rosTypescriptGenerator = async (config: IConfig) => {
   const files = flatten(
     await Promise.all(
       config.input.map((dir) => getMsgFilesData(dir.path, dir.namespace))
     )
   );
-  const joinedMessages = files
+  let joinedMessages = files
     .map((file) =>
       [`MSG: ${file.namespace}/${file.name}`, file.data].join('\n')
     )
     .join('\n===\n');
+
+  joinedMessages = disambiguatePkgOfPropertyTypes(joinedMessages);
 
   const typescriptInterfaces = generateFromRosMsg(
     joinedMessages,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
foxglove/rosmsg mixes up types with the same name, which means that ros-typescript-generator generates incorrect interfaces. For a minimal example see 
https://github.com/foxglove/rosmsg/issues/39

- **What is the new behavior (if this is a feature change)?**
When a message field's type is declared without an explicit package name, assume it refers to a type in the same package.

- **Other information**:
This should probably be fixed upstream in foxglove/rosmsg, but their parser seems rather elaborate and I couldn't figure it out, so I reported the bug there and implemented this workaround here for the time being.