### PR TITLE
Add handling for symbolic links in getMsgFiles function

### DIFF
--- a/src/lib/readMsgFiles.ts
+++ b/src/lib/readMsgFiles.ts
@@ -1,6 +1,5 @@
-import { readdir, readFile, writeFile } from 'fs/promises';
-import { join } from 'path';
-import { basename } from 'path';
+import { readdir, readFile, realpath, writeFile } from 'fs/promises';
+import { basename, join } from 'path';
 
 /* eslint-disable functional/prefer-readonly-type,functional/no-let,functional/no-loop-statement,functional/immutable-data */
 
@@ -135,6 +134,10 @@ export const getMsgFiles = async (
         tmpDir
       );
       output.push(...actionFiles);
+    } else if (entry.isSymbolicLink()) {
+      const fullPath = join(dir, entry.name);
+      const resolvedPath = await realpath(fullPath);
+      output.push(resolvedPath);
     }
   }
   return output;


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
  Feature

- **What is the current behavior?**
  The current behavior of the `getMsgFiles` function doesn't handle symbolic links.

- **What is the new behavior (if this is a feature change)?**
  This PR introduces handling for symbolic links in the `getMsgFiles` function. Now, when encountering a symbolic link, the function resolves the path and includes it in the output.

- **Other information**:
  None
