### PR TITLE
Fix symbolic link handling

### DIFF
--- a/src/lib/readMsgFiles.ts
+++ b/src/lib/readMsgFiles.ts
@@ -113,18 +113,27 @@ export const generateMsgsFromActionsFiles = async (
   }
 };
 
-async function processEntries(entries: Dirent[], dir: string) {
+async function processEntries(
+  entries: Dirent[],
+  dir: string
+): Promise<Dirent[]> {
   const processedEntries = await Promise.all(
-    entries.map(async (entry) => {
-      const fullPath = join(dir, entry.name);
-
+    entries.map(async (entry): Promise<Dirent> => {
       if (entry.isSymbolicLink()) {
+        const fullPath = join(dir, entry.name);
+
         const resolvedPath = await realpath(fullPath);
         const stats = await stat(resolvedPath);
+
         return {
-          ...entry,
           isDirectory: () => stats.isDirectory(),
           isFile: () => stats.isFile(),
+          isBlockDevice: entry.isBlockDevice,
+          isCharacterDevice: entry.isCharacterDevice,
+          isSymbolicLink: entry.isSymbolicLink,
+          isFIFO: entry.isFIFO,
+          isSocket: entry.isSocket,
+          name: entry.name,
         };
       } else {
         return entry;

--- a/src/lib/readMsgFiles.ts
+++ b/src/lib/readMsgFiles.ts
@@ -126,14 +126,14 @@ async function processEntries(
         const stats = await stat(resolvedPath);
 
         return {
+          name: entry.name,
           isDirectory: () => stats.isDirectory(),
           isFile: () => stats.isFile(),
-          isBlockDevice: entry.isBlockDevice,
-          isCharacterDevice: entry.isCharacterDevice,
-          isSymbolicLink: entry.isSymbolicLink,
-          isFIFO: entry.isFIFO,
-          isSocket: entry.isSocket,
-          name: entry.name,
+          isBlockDevice: () => entry.isBlockDevice(),
+          isCharacterDevice: () => entry.isCharacterDevice(),
+          isSymbolicLink: () => entry.isSymbolicLink(),
+          isFIFO: () => entry.isFIFO(),
+          isSocket: () => entry.isSocket(),
         };
       } else {
         return entry;


### PR DESCRIPTION
What kind of change does this PR introduce?

- Previously, the code block for handling symbolic links within the getMsgFiles function did not account for files with .srv and .action extensions, thus missing the opportunity to convert these files from .srv and .action to .msg files.
- To address this, the code now utilizes the processEntries method to convert all entries into a unified structure before processing.
- Additionally, it removes the need for separate if cases to handle symbolic links, as the conversion process within processEntries takes care of this.

What is the current behavior?
The current behavior involves the getMsgFiles function directly handling symbolic links by resolving them and pushing their paths into the output array.

What is the new behavior (if this is a feature change)?

- The new behavior involves separating the logic for processing directory entries into a separate processEntries function.
- Symbolic links are now processed within the processEntries function, where they are resolved and their properties (isDirectory, isFile) are updated accordingly.
- This separation of concerns improves code readability, maintainability, and modularity. It allows for easier extension or modification of the code related to directory entry processing.

Other information:
